### PR TITLE
Build a regular expression for commonform-regexp-annotator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+re.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+build-re.js

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Passive Aggressor is a passive voice obliterator for contracts in [Common Form](https://github.com/commonform). It is an annotator module for [commonform-critique](https://github.com/commonform/commonform-critique).
 
-So far, Passive Aggressor relies on the simple [passive-voice](https://github.com/btford/passive-voice) module by [btford](https://github.com/btford).
-
 License: Apache 2.0
 
 ## Tests
@@ -13,13 +11,13 @@ var passiveAggressor = require('passive-aggressor')
 var assert = require('assert')
 
 assert.deepEqual(
-  passiveAggressor( { content: [ 'Bob was hit by a bus, and the bird was fed a worm by its mother.' ] } ),
-  [ { message: 'The phrase "was hit" is passive voice.',
+  passiveAggressor( { content: [ 'Bob was seen by three witnesses, and the witnesses were known to be in the area.' ] } ),
+  [ { message: 'The phrase "was seen" is passive voice.',
       level: 'info',
       path: [ 'content', 0 ],
       source: 'passive-aggressor',
       url: null },
-    { message: 'The phrase "was fed" is passive voice.',
+    { message: 'The phrase "were known" is passive voice.',
       level: 'info',
       path: [ 'content', 0 ],
       source: 'passive-aggressor',

--- a/build-re.js
+++ b/build-re.js
@@ -1,8 +1,8 @@
-var irregulars = require('english-irregular-verbs');
+var irregularVerbs = require('english-irregular-verbs');
 
 // Extract all past participles.
 var irregularParticiples = [];
-irregulars.forEach(function(verb) {
+irregularVerbs.forEach(function(verb) {
   verb.participles.forEach(function(participle) {
     irregularParticiples.push(participle);
   });
@@ -10,12 +10,31 @@ irregulars.forEach(function(verb) {
 
 var toBe = [ 'am', 'are', 'were', 'being', 'is', 'been', 'was', 'be' ];
 
-// Write a Node module that exports a regular expression to standard output.
+// Write to standard output ...
 process.stdout.write(
+  // a Node module that exports ...
   'module.exports = ' +
-  'new RegExp("(\\\\b(' +
-  toBe.join('|') +
-  ')\\\\b\\\\s*([\\\\w]+ed|' +
-  irregularParticiples.join('|') +
-  ')\\\\b)", "gi")\n'
+  // a regular expression ...
+  'new RegExp("' +
+    // entirely enclosed in a capture group ...
+    '(' +
+      // that matches a form of "to be" ...
+      '\\\\b' +
+      '(' + toBe.join('|') + ')' +
+      '\\\\b' +
+      // followed by space ...
+      '\\\\s*' +
+      '(' +
+        // and a word that ends in "-ed" ...
+        '[\\\\w]+ed' +
+        // or ...
+        '|' +
+        // an irregular past participle ...
+        irregularParticiples.join('|') +
+      ')' +
+      '\\\\b' +
+    ')' +
+  '",' +
+  // that one or more case-insensitive substrings.
+  ' "gi")\n'
 );

--- a/build-re.js
+++ b/build-re.js
@@ -2,7 +2,8 @@ var irregularVerbs = require('english-irregular-verbs');
 
 // Extract all past participles.
 var irregularParticiples = [];
-irregularVerbs.forEach(function(verb) {
+Object.keys(irregularVerbs).forEach(function(infinitive) {
+  var verb = irregularVerbs[infinitive];
   verb.participles.forEach(function(participle) {
     irregularParticiples.push(participle);
   });

--- a/build-re.js
+++ b/build-re.js
@@ -1,0 +1,21 @@
+var irregulars = require('english-irregular-verbs');
+
+// Extract all past participles.
+var irregularParticiples = [];
+irregulars.forEach(function(verb) {
+  verb.participles.forEach(function(participle) {
+    irregularParticiples.push(participle);
+  });
+});
+
+var toBe = [ 'am', 'are', 'were', 'being', 'is', 'been', 'was', 'be' ];
+
+// Write a Node module that exports a regular expression to standard output.
+process.stdout.write(
+  'module.exports = ' +
+  'new RegExp("(\\\\b(' +
+  toBe.join('|') +
+  ')\\\\b\\\\s*([\\\\w]+ed|' +
+  irregularParticiples.join('|') +
+  ')\\\\b)", "gi")\n'
+);

--- a/index.js
+++ b/index.js
@@ -1,30 +1,15 @@
-var passiveVoice = require('passive-voice')
+var annotator = require('commonform-regexp-annotator');
+var re = require('./re');
 
-var annotate = function(content) {
-  /*
-    return a function to make a Common Form annotation for content
-    See: https://github.com/commonform/commonform-annotations
-
-    for content = 'Bob was hit by a bus.'
-    match will be = { index: 4, offset: 7 }
-  */
-  return function(match) {
-    var substring = content.substring(match.index, match.index + match.offset);
-    return {
-      "message": "The phrase \"" + substring + "\" is passive voice.",
-      "level": "info",
-      "path": ["content", 0],
-      "source": "passive-aggressor",
-      "url": null
-    }
-  }
+function makeAnnotation(form, path, expression, match) {
+  var phrase = match[1];
+  return {
+    level: 'info',
+    message: 'The phrase "' + phrase + '" is passive voice.',
+    path: path,
+    source: 'passive-aggressor',
+    url: null
+  };
 }
 
-var checkPassive = function(form) {
-  //TODO: handle subforms
-  var content = form['content'][0];
-
-  return passiveVoice(content).map(annotate(content));
-}
-
-module.exports = checkPassive;
+module.exports = annotator([re], makeAnnotation);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "defence-cli": "^1.0.1",
-    "english-irregular-verbs": "^0.1.0",
+    "english-irregular-verbs": "^0.2.0",
     "replace-require-self": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": " Passive voice obliterator for Common Form",
   "main": "index.js",
   "scripts": {
+    "prepublish": "node build-re.js > re.js",
+    "pretest": "npm run prepublish",
     "test": "defence README.md | replace-require-self | node"
   },
   "repository": {
@@ -26,13 +28,14 @@
   },
   "homepage": "https://github.com/anseljh/passive-aggressor#readme",
   "dependencies": {
-    "passive-voice": "^0.1.0"
+    "commonform-regexp-annotator": "^1.1.0"
   },
   "peerDependencies": {
     "commonform": "1.x"
   },
   "devDependencies": {
     "defence-cli": "^1.0.1",
+    "english-irregular-verbs": "^0.1.0",
     "replace-require-self": "^1.0.0"
   }
 }


### PR DESCRIPTION
This pull request:
1. Uses [commonform-regexp-annotator](https://npmjs.com/packages/commonform-regexp-annotator), newly updated to support global regular expressions, to generate a recursive annotator.
2. Uses an npm script to prebuild a regular expression to match passive constructs based on the regular English "-ed" suffix and a list of irregular past participles, like the one [passive-voice](https://npmjs.com/packages/passive-voice) builds internally at runtime.
3. Uses new [english-irregular-verbs](https://npmjs.com/packages/english-irregular-verbs), which contains just a short list of the most frequently used English irregular verbs, but can be expanded.
